### PR TITLE
added functionality

### DIFF
--- a/queRica/.classpath
+++ b/queRica/.classpath
@@ -6,6 +6,6 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="lib" path="/Users/joshuamendiola/Documents/MC Plugins/spigot-1.16.5.jar"/>
+	<classpathentry kind="lib" path="C:/Users/guzyw/OneDrive/Desktop/spigot-1.16.5 (1).jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/queRica/src/mcpc/PhilosophyWithJosh/queRica/Main.java
+++ b/queRica/src/mcpc/PhilosophyWithJosh/queRica/Main.java
@@ -1,12 +1,18 @@
 package mcpc.PhilosophyWithJosh.queRica;
 
+import org.bukkit.command.PluginCommand;
+import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.plugin.java.JavaPlugin;
+
+import mcpc.PhilosophyWithJosh.queRica.commands.ActivatePluginCommand;
+import mcpc.PhilosophyWithJosh.queRica.listeners.BlockBreakListener;
 
 public class Main extends JavaPlugin
 {
 	@Override
 	public void onEnable()
 	{
-		
+		new ActivatePluginCommand(this);
+		new BlockBreakListener(this);
 	}
 }

--- a/queRica/src/mcpc/PhilosophyWithJosh/queRica/commands/ActivatePluginCommand.java
+++ b/queRica/src/mcpc/PhilosophyWithJosh/queRica/commands/ActivatePluginCommand.java
@@ -1,7 +1,35 @@
 package mcpc.PhilosophyWithJosh.queRica.commands;
 
+import java.util.concurrent.Executor;
 
-public class ActivatePluginCommand 
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+import mcpc.PhilosophyWithJosh.queRica.Main;
+
+public class ActivatePluginCommand implements CommandExecutor
 {
+	private Main plugin;
+	private static boolean commandIsActive = false;
+	public ActivatePluginCommand(Main plugin)
+	{
+		this.plugin = plugin;
+		plugin.getCommand("qrtoggle").setExecutor(this);
+	}
 	
+	public boolean onCommand(CommandSender sender, Command beblockhunter, String label, String[] args)
+	
+	{
+		plugin.getServer().broadcastMessage("plugin toggled");
+		commandIsActive = !commandIsActive;
+		return true;
+	}
+
+	public static boolean commandIsActive() {
+		return commandIsActive;
+	}
+
 }
+	
+

--- a/queRica/src/mcpc/PhilosophyWithJosh/queRica/listeners/BlockBreakListener.java
+++ b/queRica/src/mcpc/PhilosophyWithJosh/queRica/listeners/BlockBreakListener.java
@@ -1,17 +1,25 @@
 package mcpc.PhilosophyWithJosh.queRica.listeners;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
 
 import mcpc.PhilosophyWithJosh.queRica.Main;
+import mcpc.PhilosophyWithJosh.queRica.commands.ActivatePluginCommand;
 
 public class BlockBreakListener implements Listener
 {
 	private Main plugin;
-	
+	ArrayList<ItemStack> drops = new ArrayList<ItemStack>();
 	public BlockBreakListener(Main plugin)
 	{
 		this.plugin = plugin;
@@ -22,5 +30,31 @@ public class BlockBreakListener implements Listener
 	public void playerBrokeBlock(BlockBreakEvent bbe)
 	{
 		
+		if(ActivatePluginCommand.commandIsActive())
+			drops.clear();
+			bbe.setCancelled(true);
+			bbe.getPlayer().sendMessage("Plugin Works");
+		
+		
+			Block brokenBlock = bbe.getBlock();
+			Collection<ItemStack> itemList = brokenBlock.getDrops();
+			Location blockLocation = brokenBlock.getLocation();
+			
+			
+			for(ItemStack item: itemList) 
+			{
+				int randomNumber = (int) (Math.random() * 25);
+				Material dropped = item.getType();
+				
+				drops.add(new ItemStack (dropped,randomNumber));
+				//ItemStack desiredDrops = new ItemStack(dropped,randomNumber);
+			}
+			
+			brokenBlock.setType(Material.AIR);
+			
+			for (int i = 0; i < drops.size(); i++) 
+			{
+				brokenBlock.getWorld().dropItemNaturally(blockLocation, drops.get(i));
+			}
 	}
 }

--- a/queRica/src/plugin.yml
+++ b/queRica/src/plugin.yml
@@ -5,3 +5,5 @@ api-version: 1.16
 main: mcpc.PhilosophyWithJosh.queRica.Main
 description: randomizes the drops of blocks broken by the player
 commands:
+  qrtoggle:
+    description: activates plugin


### PR DESCRIPTION
Added in a command that could toggle the plugin on and off

Added a listener checks to see if blocks were broken, cancels the event, turns the block into air, and naturally drops a random amount (between 1 and 25) of that item onto the ground.